### PR TITLE
Fix compilation of coordRegStart initializer

### DIFF
--- a/FT5206.h
+++ b/FT5206.h
@@ -84,7 +84,7 @@ class FT5206 {
 	uint8_t 			_ctpInt;
 	uint8_t				_maxTouch;
 	enum FT5206isr 		_isrMode;
-	const uint8_t coordRegStart[5] = {{0x03},{0x09},{0x0F},{0x15},{0x1B}};
+	const uint8_t coordRegStart[5] = {0x03,0x09,0x0F,0x15,0x1B};
 };
 
 #endif


### PR DESCRIPTION
Minor fix to avoid Arduino IDE (version 1.8.10) compiler error:

```
...\Arduino\libraries\FT5206-master/FT5206.h:87:70: error: braces around scalar initializer for type 'const uint8_t {aka const unsigned char}'
  const uint8_t coordRegStart[5] = {{0x03},{0x09},{0x0F},{0x15},{0x1B}};
```